### PR TITLE
Add extremely rudimentary templating abilities

### DIFF
--- a/src/view/ui/MarkdownHolder.svelte
+++ b/src/view/ui/MarkdownHolder.svelte
@@ -23,6 +23,10 @@
     let plugin = getContext<StatBlockPlugin>("plugin");
     let layout = getContext<Layout>("layout");
 
+    property = property.replaceAll("${HP}", monster.hp)
+      .replaceAll("${AC}", monster.ac)
+      .replaceAll("${INIMOD}", (monster.modifier > 0 ? "+" : "-") +  monster.modifier);
+
     let split: Array<{ text: string; original?: string } | string> = [property];
     if (dice) {
         if (


### PR DESCRIPTION
Adds very simple templating to statblock text.

Replaces:
- `${HP}` with the HP of the monster
- `${AC}` with the AC of the monster
- `${INIMOD}` with the initiative modifier of the monster

This is useful for ability descriptions, but also helps reduce duplication in the pf2e statblocks. Before:
```
modifier: 4
perception:
  - name: Perception
    desc: Perception +4; darkvision
```

After:
```
modifier: 4
perception:
  - name: Perception
    desc: Perception ${INIMOD}; darkvision
```

This seemed like the simplest implementation but let me know if there's a better spot to put this :)